### PR TITLE
Evidenziare presenza di eventi da approvare

### DIFF
--- a/base/context_processors.py
+++ b/base/context_processors.py
@@ -1,5 +1,32 @@
 from django.conf import settings
+from base.models import CLASS_CHOICES
+from events.models import Event
 
 
 def demo(request):
     return {'DEMO': settings.DEMO}
+
+
+def waiting_events_counter(request):
+    """
+    The variable name is "waiting_events_count"
+    Return the number of events that the user can approve or refuse. The user has to have the
+    correct permissions which include that to manage the category of the relative activity.
+    If the user is not logged in or does not have the required permissions it returns None
+    """
+    if (request.user.is_authenticated and
+            request.user.has_perms(("events.change_event", "activities.change_activity"))):
+        # Get the managed category
+        managed_category = [c[0] for c in CLASS_CHOICES
+                            if request.user.has_perm("activities.change_" + c[0])]
+        # Filter the events and count them
+        event_count = Event.objects.filter(
+            status=Event.WAITING,
+            activity__category__in=managed_category
+        ).filter(
+            room__roompermission__group__in=request.user.groups.all(),
+            room__roompermission__permission=30
+        ).distinct().count()
+        return {"waiting_events_count": event_count}
+    else:
+        return {"waiting_events_count": None}

--- a/base/static/css/custom.css
+++ b/base/static/css/custom.css
@@ -35,6 +35,10 @@ body {
 .error-message {
 	margin-top: 5%;
 }
+
+#navbar>ul>li>a>span.badge {
+    line-height: 13px;
+}
 /* JQUERY SUMOSELECT style like bootstrap form-control */
 
 div.SumoSelect {

--- a/base/templates/base/layout.html
+++ b/base/templates/base/layout.html
@@ -50,7 +50,7 @@
 				<li><a href="{% url "activities:list" %}">Attività</a></li>
 				<li><a href="{% url "rooms:list" %}">Aule</a></li>
 				<li><a href="{% url "news:news" %}">Avvisi</a></li>
-                                {% if user.is_authenticated %}
+                                {% if user.is_authenticated and perms.events.change_event and perms.activities.change_activity %}
 				<li><a href="{% url "events:approvation" %}">Approvazioni</a></li>
                                 {% endif %}
 			</ul>

--- a/base/templates/base/layout.html
+++ b/base/templates/base/layout.html
@@ -50,9 +50,15 @@
 				<li><a href="{% url "activities:list" %}">Attività</a></li>
 				<li><a href="{% url "rooms:list" %}">Aule</a></li>
 				<li><a href="{% url "news:news" %}">Avvisi</a></li>
-                                {% if user.is_authenticated and perms.events.change_event and perms.activities.change_activity %}
-				<li><a href="{% url "events:approvation" %}">Approvazioni</a></li>
-                                {% endif %}
+                {% if user.is_authenticated and perms.events.change_event and perms.activities.change_activity %}
+				    <li>
+                        <a href="{% url "events:approvation" %}">Approvazioni
+                            {% if waiting_events_count and waiting_events_count != 0 %}
+                                <span class="badge">{{ waiting_events_count }}</span>
+                            {% endif %}
+                        </a>
+                    </li>
+                {% endif %}
 			</ul>
 			<ul class="nav navbar-nav navbar-right">
 				{% if DEMO %}<li><p class="navbar-text" id="demo-message">Questo sito è una DEMO in continuo sviluppo.</p></li>{% endif %}

--- a/booking/settings.py
+++ b/booking/settings.py
@@ -89,6 +89,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.i18n',
                 'base.context_processors.demo',
+                'base.context_processors.waiting_events_counter',
             ],
         },
     },


### PR DESCRIPTION
Resolve: #93 

Aggiunto context processor per avere il numero di eventi in attesa che l'utente può approvare.
Se ce ne sono viene mostrato un badge in parte al menù `Approvazioni` con tale numero.